### PR TITLE
feat: add session management regions refresh command

### DIFF
--- a/portal_client/__init__.py
+++ b/portal_client/__init__.py
@@ -10,7 +10,10 @@ from .client_application_uploader import (
     configure_parser as configure_client_application_parser,
 )
 from .organizations import configure_organizations_parser
-from .session_management import configure_session_management_parser
+from .session_management import (
+    configure_regions_parser,
+    configure_session_management_parser,
+)
 from .usergroups import configure_user_groups_parser
 from .users import configure_users_parser
 
@@ -61,3 +64,8 @@ configure_organizations_parser(organizations_parser)
 
 vm_parser = subparsers.add_parser("vms", help="Manage Virtual Machines")
 configure_session_management_parser(vm_parser)
+
+regions_parser = subparsers.add_parser(
+    "regions", help="Manage regions via session management"
+)
+configure_regions_parser(regions_parser)

--- a/portal_client/session_management.py
+++ b/portal_client/session_management.py
@@ -66,6 +66,26 @@ class SessionManagementApiClient:
 
         return response.json()
 
+    @backoff.on_exception(
+        backoff.expo, requests.exceptions.ConnectionError, max_time=60
+    )
+    def refresh_regions(self):
+        """
+        Force an immediate refresh of the cached cloud resources (subnets,
+        gateways, and VM images) across all regions, bypassing the configured
+        cache expiry. Use after publishing a new VM image so it is picked up
+        without waiting for the background refresh cycle. Admin only.
+        """
+        response = requests.post(
+            urljoin(self.base_url, "/Regions/refresh"),
+            headers={"Authorization": get_bearer_authorization_header()},
+            timeout=30,
+        )
+
+        if not response.ok:
+            print(response.text)
+        response.raise_for_status()
+
 
 def list_vms_cli(args):
     """CLI wrapper for listing VMs"""
@@ -81,6 +101,13 @@ def extend_vm_expiration_cli(args):
         vm_id=args.vm_id, organization_id=args.org_id, timespan=args.time
     )
     print(json.dumps(response))
+
+
+def refresh_regions_cli(args):
+    """CLI wrapper for refreshing cloud resources across all regions"""
+    client = SessionManagementApiClient()
+    client.refresh_regions()
+    print("Successfully triggered a refresh of cloud resources across all regions.")
 
 
 def configure_session_management_parser(parser: argparse.ArgumentParser):
@@ -112,20 +139,33 @@ def configure_session_management_parser(parser: argparse.ArgumentParser):
     return vm_parser
 
 
+def configure_regions_parser(parser: argparse.ArgumentParser):
+    """Configure the CLI parser for region management commands"""
+    regions_parser = parser.add_subparsers(
+        description="Manage regions via session management"
+    )
+
+    # regions refresh command
+    regions_refresh_parser = regions_parser.add_parser(
+        "refresh",
+        help="Force an immediate refresh of cached cloud resources across all regions",
+    )
+    regions_refresh_parser.set_defaults(func=refresh_regions_cli)
+
+    return regions_parser
+
+
 # Define CLI args for standalone usage
 def configure_parser(parser):
     return configure_session_management_parser(parser)
 
 
-def main(args):
-    """Main function for standalone usage"""
+if __name__ == "__main__":
+    # Execute when the module is not initialized from an import statement.
+    parser = argparse.ArgumentParser()
+    configure_parser(parser)
+    args = parser.parse_args()
     if hasattr(args, "func"):
         args.func(args)
     else:
         parser.print_help()
-
-
-if __name__ == "__main__":
-    # Execute when the module is not initialized from an import statement.
-    args = configure_parser(parser=argparse.ArgumentParser()).parse_args()
-    main(args)

--- a/readme.md
+++ b/readme.md
@@ -85,6 +85,14 @@ innoactive-portal applications v2 upload-build \
 
 You can run `innoactive-portal applications v2 upload-build --help` to get more information on available parameters.
 
+### Refreshing region resources
+
+Forces an immediate refresh of the cached cloud resources (subnets, gateways, and VM images) across all regions in session management, bypassing the configured cache expiry. Useful after publishing a new VM image so it is picked up without waiting for the background refresh cycle. Requires admin access.
+
+```sh
+innoactive-portal regions refresh
+```
+
 ## Development
 
 To run the client locally, you can clone the repository and install the dependencies via uv:

--- a/tests/test_session_management.py
+++ b/tests/test_session_management.py
@@ -10,6 +10,7 @@ from portal_client.session_management import (
     SessionManagementApiClient,
     extend_vm_expiration_cli,
     list_vms_cli,
+    refresh_regions_cli,
 )
 
 
@@ -90,6 +91,41 @@ class TestSessionManagementApiClient:
 
         assert result == expected_response
 
+    def test_refresh_regions_success(self, requests_mock):
+        # The endpoint returns 200 OK with no content body
+        requests_mock.post(
+            "https://session-management.innoactive.io/Regions/refresh",
+            status_code=200,
+        )
+
+        client = SessionManagementApiClient()
+        with patch(
+            "portal_client.session_management.get_bearer_authorization_header",
+            return_value="Bearer test-token",
+        ):
+            result = client.refresh_regions()
+
+        assert result is None
+        assert requests_mock.last_request.method == "POST"
+        assert (
+            requests_mock.last_request.headers["Authorization"] == "Bearer test-token"
+        )
+
+    def test_refresh_regions_error_response(self, requests_mock):
+        requests_mock.post(
+            "https://session-management.innoactive.io/Regions/refresh",
+            text="Forbidden",
+            status_code=403,
+        )
+
+        client = SessionManagementApiClient()
+        with patch(
+            "portal_client.session_management.get_bearer_authorization_header",
+            return_value="Bearer test-token",
+        ):
+            with pytest.raises(requests.HTTPError):
+                client.refresh_regions()
+
     def test_list_vms_error_response(self, requests_mock):
         # Mock an error response
         error_response = {"error": "Unauthorized"}
@@ -162,3 +198,26 @@ class TestSessionManagementCLI:
         # Verify output
         output = mock_stdout.getvalue().strip()
         assert json.loads(output) == expected_response
+
+    def test_refresh_regions_cli(self, requests_mock):
+        # The endpoint returns 200 OK with no content body
+        requests_mock.post(
+            "https://session-management.innoactive.io/Regions/refresh",
+            status_code=200,
+        )
+
+        class MockArgs:
+            pass
+
+        args = MockArgs()
+
+        with patch(
+            "portal_client.session_management.get_bearer_authorization_header",
+            return_value="Bearer test-token",
+        ):
+            with patch("sys.stdout", new_callable=StringIO) as mock_stdout:
+                refresh_regions_cli(args)
+
+        output = mock_stdout.getvalue().strip()
+        assert "Successfully triggered a refresh" in output
+        assert requests_mock.last_request.method == "POST"


### PR DESCRIPTION
## Summary

Adds the first session-management **region** command: `innoactive-portal regions refresh`.

It calls `POST /Regions/refresh` on the session management API, which forces an immediate refresh of the cached cloud resources (subnets, gateways, and VM images) across all regions, bypassing the configured cache expiry. Useful after publishing a new VM image so it is picked up without waiting for the background refresh cycle. **Admin only.**

## Changes

- **`portal_client/session_management.py`**
  - `SessionManagementApiClient.refresh_regions()` — `POST /Regions/refresh` with bearer auth and connection-error backoff, matching the existing VM methods. The endpoint returns `200` with no body, so it raises on error and returns nothing rather than parsing JSON.
  - `refresh_regions_cli` wrapper + `configure_regions_parser`.
  - Fixes a **pre-existing** bug in the standalone `__main__` block: `main()` referenced an undefined `parser`, and `parse_args()` was called on the subparsers action rather than the `ArgumentParser`. (Latent because CI only runs `pytest`, not `ruff`.)
- **`portal_client/__init__.py`** — registers a top-level `regions` command (consistent with how `vms` maps to session-management VirtualMachines).
- **`tests/test_session_management.py`** — 3 new tests: client success (no-body `200`), client error (`403` → `HTTPError`), and the CLI wrapper.
- **`readme.md`** — short "Refreshing region resources" example.

## Notes

- `refresh_regions()` uses `get_bearer_authorization_header()` (bearer token only), matching the existing VM methods — so this command requires `PORTAL_BACKEND_ACCESS_TOKEN`. Happy to switch it to `get_authorization_header()` for username/password fallback if preferred.

## Testing

- `uv run ruff check` — clean
- `uv run ruff format --check` — clean
- `uv run pytest` — 12 passed (3 new)
- Verified CLI wiring: `innoactive-portal regions refresh --help`

🤖 Generated with [Claude Code](https://claude.com/claude-code)