### PR TITLE
ci: bump GitHub Actions to Node.js 24 runtimes

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -10,13 +10,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v7
       - name: Setup python version
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v7
         with:
           python-version: "3.12"
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v7
       - name: Install dependecies
         run: uv sync --locked
       - name: Run tests

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,17 +11,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v7
       - name: Setup python version
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v7
         with:
           python-version: "3.12"
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v7
       - name: Install dependecies
         run: uv sync --locked
       - name: Semantic Release
-        uses: cycjimmy/semantic-release-action@v4
+        uses: cycjimmy/semantic-release-action@v6
         with:
           extra_plugins: |
             @semantic-release/exec


### PR DESCRIPTION
## Summary

GitHub Actions runners have deprecated Node.js 20 ([changelog](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/)). CI was emitting a warning that `actions/checkout@v3`, `actions/setup-python@v2`, `astral-sh/setup-uv@v5`, and `cycjimmy/semantic-release-action@v4` were being force-run on Node.js 24.

This bumps each action to its newest reference whose `action.yml` declares `using: node24`, clearing the warning.

| Action | Before | After |
|---|---|---|
| `actions/checkout` | `@v3` | `@v7` |
| `actions/setup-python` | `@v2` | `@v7` |
| `astral-sh/setup-uv` | `@v5` | `@v7` |
| `cycjimmy/semantic-release-action` | `@v4` | `@v6` |

## Notes

- Pinned to **movable major references** to match the repo's existing style (`checkout`/`setup-python` use major tags, `semantic-release-action` uses a major branch).
- For `astral-sh/setup-uv`, `v7` is the newest movable major tag — the maintainers publish v8/v9 only as exact versions (e.g. `@v9.0.0`). Can pin to an exact latest instead if preferred.
- Usage of each action is unchanged (`python-version`, `extra_plugins`, etc. inputs are stable across these majors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)