### PR TITLE
ci: fix release push to protected main (bypass token)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,14 +8,25 @@ on:
 jobs:
   release:
     name: Semantic Release
-    # Shared org workflow: checks out this repo, runs semantic-release with the
-    # SEMANTIC_RELEASE_GH_TOKEN, whose identity is on main's branch-protection
-    # bypass list — so the @semantic-release/git push to the protected main
-    # branch is accepted (the default GITHUB_TOKEN is not allowed to bypass).
-    uses: Innoactive/Portal-Backend/.github/workflows/semantic-release.yml@develop
-    secrets:
-      gh_token: ${{ secrets.SEMANTIC_RELEASE_GH_TOKEN }}
-    with:
-      extra-semantic-release-plugins: |
-        @semantic-release/exec
-        @semantic-release/git
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          # Full history + tags so semantic-release can determine the next version.
+          fetch-depth: 0
+          # Must be false: otherwise checkout stores the default GITHUB_TOKEN as a git
+          # auth header and the release push would use it (github-actions[bot], which is
+          # NOT on main's bypass list → GH006). With no persisted credentials, the push
+          # uses the SEMANTIC_RELEASE_GH_TOKEN below instead.
+          persist-credentials: false
+      - name: Semantic Release
+        uses: cycjimmy/semantic-release-action@v6
+        with:
+          extra_plugins: |
+            @semantic-release/exec
+            @semantic-release/git
+        env:
+          # Repo-scoped token whose identity bypasses PR protection on main, so the
+          # @semantic-release/git version-bump commit can be pushed to the protected branch.
+          GITHUB_TOKEN: ${{ secrets.SEMANTIC_RELEASE_GH_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,24 +7,15 @@ on:
 
 jobs:
   release:
-    name: Release
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v7
-      - name: Setup python version
-        uses: actions/setup-python@v7
-        with:
-          python-version: "3.12"
-      - name: Install uv
-        uses: astral-sh/setup-uv@v7
-      - name: Install dependecies
-        run: uv sync --locked
-      - name: Semantic Release
-        uses: cycjimmy/semantic-release-action@v6
-        with:
-          extra_plugins: |
-            @semantic-release/exec
-            @semantic-release/git
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    name: Semantic Release
+    # Shared org workflow: checks out this repo, runs semantic-release with the
+    # SEMANTIC_RELEASE_GH_TOKEN, whose identity is on main's branch-protection
+    # bypass list — so the @semantic-release/git push to the protected main
+    # branch is accepted (the default GITHUB_TOKEN is not allowed to bypass).
+    uses: Innoactive/Portal-Backend/.github/workflows/semantic-release.yml@develop
+    secrets:
+      gh_token: ${{ secrets.SEMANTIC_RELEASE_GH_TOKEN }}
+    with:
+      extra-semantic-release-plugins: |
+        @semantic-release/exec
+        @semantic-release/git


### PR DESCRIPTION
## Problem

The Release pipeline fails on the **Semantic Release** step ([example run](https://github.com/Innoactive/Portal-Python-CLI/actions/runs/29992049927)):

```
git push --tags https://github.com/Innoactive/Portal-Python-CLI HEAD:main
remote: error: GH006: Protected branch update failed for refs/heads/main.
- Changes must be made through a pull request.
```

`.releaserc.json` uses `@semantic-release/git`, which commits the version bump to `pyproject.toml` and pushes it to `main`. But `main` is protected (requires a PR, `enforce_admins` on), and the default `GITHUB_TOKEN` / `github-actions[bot]` is not on the bypass list — so the push is declined and no release is published.

## Fix

Run semantic-release with a **repo-scoped `SEMANTIC_RELEASE_GH_TOKEN`** whose identity bypasses PR protection on `main`.

Notes on the approach:
- **Inline, not the shared org workflow.** This repo is **public** and the org's reusable `semantic-release.yml` lives in the **private** `Portal-Backend` repo. GitHub does not allow a public repo to call a private repo's reusable workflow, so the release job is defined directly here instead.
- **`persist-credentials: false`** on checkout is required: otherwise `actions/checkout` stores the default `GITHUB_TOKEN` as a git auth header and the push would use *that* (-> GH006 again) instead of the bypass token.
- **Repo-scoped token** was chosen over sharing the broad org-wide token with this public repo, to keep the credential's blast radius limited to this repo (a repo secret overrides the org secret of the same name).
- Dropped the inline Python/uv setup — the version bump (`scripts/update-version-number.sh`) is pure `sed` and there is no publish step.

## Prerequisites (GitHub settings)

- [x] Repo-scoped `SEMANTIC_RELEASE_GH_TOKEN` secret created
- [ ] Token identity added to `main`'s branch-protection PR-bypass list (currently only `burnedikt`)
- [ ] Token has `Contents: write`

## Testing

The release workflow only triggers on `push` to `main`, so this is validated by the next merge to `main` producing a release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)