### PR TITLE
fix: authenticate the client application version lookup

### DIFF
--- a/portal_client/client_application_uploader.py
+++ b/portal_client/client_application_uploader.py
@@ -45,7 +45,12 @@ class ClientApplicationApiClient:
         backoff.expo, requests.exceptions.ConnectionError, max_time=60
     )
     def retrieve_client_application_version(self, slug, version):
-        return requests.get(urljoin(self.base_url, f"{slug}/versions/{version}/"))
+        # authenticate: reads of superseded versions are not available anonymously, so without credentials this
+        # would report an already existing version as missing
+        return requests.get(
+            urljoin(self.base_url, f"{slug}/versions/{version}/"),
+            headers={"Authorization": get_authorization_header()},
+        )
 
     @backoff.on_exception(
         backoff.expo, requests.exceptions.ConnectionError, max_time=60

--- a/tests/test_client_application_uploader.py
+++ b/tests/test_client_application_uploader.py
@@ -1,0 +1,31 @@
+from unittest.mock import patch
+
+import requests_mock
+
+from portal_client.client_application_uploader import ClientApplicationApiClient
+
+
+def test_version_lookup_is_authenticated(requests_mock: requests_mock.Mocker):
+    """The duplicate check before an upload has to authenticate: the backend only serves the *current* version of a
+    client application anonymously, so an unauthenticated lookup reports an already existing - but by now superseded -
+    version as missing, and the upload then fails later on the uniqueness constraint instead of aborting cleanly.
+    """
+    # Given a backend that serves the details of an existing client application version
+    api_client = ClientApplicationApiClient(base_url="https://portal.test")
+    requests_mock.get(
+        "https://portal.test/api/client-applications/desktop-client/versions/1.2.3/",
+        json={"version": "1.2.3"},
+    )
+
+    # When looking up that version
+    with patch(
+        "portal_client.client_application_uploader.get_authorization_header",
+        return_value="Bearer token",
+    ):
+        response = api_client.retrieve_client_application_version(
+            "desktop-client", "1.2.3"
+        )
+
+    # Then expect the request to have carried the credentials
+    assert response.status_code == 200
+    assert requests_mock.last_request.headers["Authorization"] == "Bearer token"


### PR DESCRIPTION
`retrieve_client_application_version()` was the only request in `ClientApplicationApiClient` that sent no `Authorization` header. `main()` uses it as the pre-flight duplicate check before an upload:

```python
check_response = client_applications_api.retrieve_client_application_version(args.slug, args.version)
if check_response.status_code < 400:
    print(f"Version {args.version} already existing! Aborting.")
    exit(1)
```

Portal only serves the **current** version of a client application to anonymous callers, so for any version that has since been superseded the unauthenticated lookup gets a 404 and the check concludes "doesn't exist". The binary is then chunk-uploaded and the run fails on the backend's uniqueness constraint with a bare 400 — instead of aborting cleanly before doing any work.

Normal releases are unaffected either way (a genuinely new version 404s before and after). This only shows up when re-uploading a version that already exists and is no longer current — e.g. re-running a release job.

Sending the credentials the rest of the client already uses restores the clean abort. Added `tests/test_client_application_uploader.py` to pin that the lookup carries the header.

Context: this surfaced while auditing consumers of the client-application endpoints for Innoactive/Portal-Backend#2280, which tightens anonymous read access to superseded versions.

`uv run --group dev pytest` → 34 passed. `ruff check` / `ruff format --check` clean on both touched files (the repo has pre-existing findings elsewhere, untouched here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
